### PR TITLE
In initialize_kalite, close db connection

### DIFF
--- a/kalite/distributed/management/commands/initialize_kalite.py
+++ b/kalite/distributed/management/commands/initialize_kalite.py
@@ -1,15 +1,15 @@
 """
 This is a command-line tool to execute functions helpful to testing.
 """
-
 from django.conf import settings
-logging = settings.LOG
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import DatabaseError
 
 from fle_utils.config.models import Settings
-from securesync.models import Device
+
+logging = settings.LOG
 
 
 class Command(BaseCommand):
@@ -30,11 +30,12 @@ class Command(BaseCommand):
             from kalite.version import VERSION
             assert Settings.get("database_version") == VERSION
         except (DatabaseError, AssertionError):
+            from django import db
+            db.close_connection()  # So that the database file is free.
             logging.info("Setting up KA Lite; this may take a few minutes; please wait!\n")
             call_command("setup", interactive=False)
             # Double check the setup process worked ok.
             assert Settings.get("database_version") == VERSION, "There was an error configuring the server. Please report the output of this command to Learning Equality."
-
 
     def handle(self, *args, **options):
 


### PR DESCRIPTION
We determine whether to run setup by checking the database, thus
opening a database connection. With sqlite, that means file access.
In that case we'll call setup, and setup will try move the database
file, but it can't (at least on Windows) because the file is open.
So close the database connection (thus releasing the file) before
calling setup. Ta-da!

@benjaoming 
